### PR TITLE
Allow keyboard interactivity

### DIFF
--- a/src/implementations/cairo-dock-wayland-manager.c
+++ b/src/implementations/cairo-dock-wayland-manager.c
@@ -369,6 +369,18 @@ void _layer_shell_init_for_window (GldiContainer *pContainer)
 	else
 	{
 		gtk_layer_init_for_window (window);
+		// Note: to enable receiving any keyboard events, we need both the compositor
+		// and gtk-layer-shell to support version >= 4 of the layer-shell protocol.
+		// Here we test if we are compiling against a version of gtk-layer-shell that
+		// has this functionality. Setting keyboard interactivity may still fail at
+		// runtime if the compositor does not support this. In this case, the dock
+		// will not receive keyboard events at all.
+		// TODO: make this optional, so that cairo-dock can be compiled targeting an
+		// older version of gtk-layer-shell (even if a newer version is installed;
+		// since versions are ABI compatible, this is possible)
+#ifdef GTK_LAYER_SHELL_KEYBOARD_MODE_ENTRY_NUMBER
+		gtk_layer_set_keyboard_interactivity (window, GTK_LAYER_SHELL_KEYBOARD_MODE_ON_DEMAND);
+#endif
 		gtk_layer_set_namespace (window, "cairo-dock");
 	}
 }


### PR DESCRIPTION
This is required for the dock to receive any keyboard events.

Requires support for layer-shell version >= 4 in the compositor and in gtk-layer-shell.

This will compile cairo-dock with keyboard interactivity enabled if the gtk-layer-shell library at compile time supports it. TODO: make this optional, so that cairo-dock can be compiled with a newer version of gtk-layer-shell installed, but used with an older version (or just require gtk-layer-shell 0.5.2 or newer for this).